### PR TITLE
adds back width on sponsor imgs

### DIFF
--- a/src/pages/Home/_pillar.home.sponsors.source.scss
+++ b/src/pages/Home/_pillar.home.sponsors.source.scss
@@ -24,6 +24,7 @@
 .p-landing_sponsors__medium img {
   flex-basis: 250px;
   height: auto;
+  width: 23%;
   margin: 0 $spacing_200;
   margin-top: $spacing_200;
   font-size: 250%;


### PR DESCRIPTION
Before:
<img width="1369" alt="screen shot 2018-09-06 at 10 36 40 am" src="https://user-images.githubusercontent.com/22671016/45165583-20184280-b1c3-11e8-90ff-a6cd4bef32a8.png">

After:
<img width="1189" alt="screen shot 2018-09-06 at 10 54 34 am" src="https://user-images.githubusercontent.com/22671016/45165669-43db8880-b1c3-11e8-85f0-94be579b0a21.png">
