### PR TITLE
Cache must revalidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ deploy:
   # Prevent Travis from deleting your built site so it can be uploaded.
   skip_cleanup: true
   local_dir: build
-  cache_control: "max-age=180"
+  cache_control: "max-age=180, must-revalidate"
 after_deploy:
   # Allow `awscli` to make requests to CloudFront.
   - aws configure set preview.cloudfront true


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Expiration, the `max-age` directive is relative to the client's request. This means the page is not stale until the user is on it for more than 180s.

With `must-revalidate`, it should revalidate all resources before using them from the browser cache.